### PR TITLE
Adding accessibility support

### DIFF
--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -121,11 +121,12 @@ in another form (e.g. a text block following the spinner).
         // Allow user-provided `aria-label` take preference to any other text alternative.
         if (this.hasAttribute('aria-label')) {
           this.alt = this.getAttribute('aria-label');
+        } else {
+          this.setAttribute('aria-label', this.alt);
         }
         if (!this.active) {
           this.setAttribute('aria-hidden', 'true');
         }
-        this.setAttribute('aria-label', this.alt);
       },
 
       activeChanged: function() {

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -31,6 +31,8 @@ that it uses one color only.
 
 Alt attribute should be set to provide adequate context for accessibility. If not provided,
 it defaults to 'loading'.
+Empty alt can be provided to mark the element as decorative if alternative content is provided
+in another form (e.g. a text block following the spinner).
 
 ##### Example
   <paper-spinner alt="Loading contacts list" active></paper-spinner>
@@ -106,8 +108,8 @@ it defaults to 'loading'.
 
         /**
          * Alternative text content for accessibility support.
-         * If alt is present and not empty, it will add an aria-label whose content matches alt when active.
-         * If alt is not present or is empty, it will default to 'loading' as the alt value.
+         * If alt is present, it will add an aria-label whose content matches alt when active.
+         * If alt is not present, it will default to 'loading' as the alt value.
          * @attribute alt
          * @type string
          * @default 'loading'
@@ -138,6 +140,11 @@ it defaults to 'loading'.
       },
 
       altChanged: function() {
+        if (this.alt === '') {
+          this.setAttribute('aria-hidden', 'true');
+        } else {
+          this.removeAttribute('aria-hidden');
+        }
         this.setAttribute('aria-label', this.alt);
       },
 

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -29,14 +29,19 @@ that it uses one color only.
 
     <paper-spinner class="blue" active></paper-spinner>
 
+Alt attribute should be set to provide adequate context for accessibility. If not provided,
+it defaults to 'loading'.
+
+##### Example
+  <paper-spinner alt="Loading contacts list" active></paper-spinner>
+
 @element paper-spinner
 @blurb Element providing material design circular spinner.
 @status alpha
 @homepage http://polymerlabs.github.io/paper-spinner
 -->
 
-<polymer-element name="paper-spinner" attributes="active">
-
+<polymer-element name="paper-spinner" attributes="active alt" role="progressbar">
   <template>
     <link rel="stylesheet" href="paper-spinner.css">
 
@@ -97,16 +102,43 @@ that it uses one color only.
          * @type boolean
          * @default false
          */
-        active: {value: false, reflect: true}
+        active: {value: false, reflect: true},
+
+        /**
+         * Alternative text content for accessibility support.
+         * If alt is present and not empty, it will add an aria-label whose content matches alt when active.
+         * If alt is not present or is empty, it will default to 'loading' as the alt value.
+         * @attribute alt
+         * @type string
+         * @default 'loading'
+         */
+        alt: {value: 'loading', reflect: true}
+      },
+
+      ready: function() {
+        // Allow user-provided `aria-label` take preference to any other text alternative.
+        if (this.hasAttribute('aria-label')) {
+          this.alt = this.getAttribute('aria-label');
+        }
+        if (!this.active) {
+          this.setAttribute('aria-hidden', 'true');
+        }
+        this.setAttribute('aria-label', this.alt);
       },
 
       activeChanged: function() {
         if (this.active) {
           this.$.spinnerContainer.classList.remove('cooldown');
           this.$.spinnerContainer.classList.add('active');
+          this.removeAttribute('aria-hidden');
         } else {
           this.$.spinnerContainer.classList.add('cooldown');
+          this.setAttribute('aria-hidden', 'true');
         }
+      },
+
+      altChanged: function() {
+        this.setAttribute('aria-label', this.alt);
       },
 
       reset: function() {


### PR DESCRIPTION
Adds aria role of `progressbar` and exposes an `alt` attribute that will be used as `aria-label`.
`alt` defaults to `loading` if not specified, not great for internationalization but in my opinion better than the alternative which would make it hidden from screen readers.
Also setting `aria-hidden` when active state changes.
