### PR TITLE
0.8 conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,20 @@
 {
   "name": "paper-spinner",
   "private": true,
+  "authors": [
+    "The Polymer Authors"
+  ],
   "dependencies": {
-    "polymer": "Polymer/polymer#0.8-preview",
-    "webcomponentsjs": "Polymer/webcomponentsjs#master"
+    "layout": "Polymer/layout",
+    "polymer": "Polymer/polymer#0.8-preview"
+  },
+  "devDependencies": {
+    "webcomponentsjs": "Polymer/webcomponentsjs#master",
+    "core-component-page": "Polymer/core-component-page#~0.5.5"
+  },
+  "main": "paper-spinner.html",
+  "repo": {
+    "type": "git",
+    "url": "git://github.com/Polymer/paper-spinner.git"
   }
 }

--- a/demo.html
+++ b/demo.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <!--
-    @license
-    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
-    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-    Code distributed by Google as part of the polymer project is also
-    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+  @license
+  Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+  This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+  The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+  The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+  Code distributed by Google as part of the polymer project is also
+  subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html lang="en">
 <head>

--- a/demo.html
+++ b/demo.html
@@ -9,38 +9,41 @@
   subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title></title>
-  <script src="../webcomponentsjs/webcomponents.js"></script>
-  <link rel="import" href="paper-spinner.html">
-  <style shim-shadowdom>
-  paper-spinner.blue .circle {
-    border-color: #4285f4;
-  }
 
-  paper-spinner.red .circle {
-    border-color: #db4437;
-  }
+  <head>
+    <meta charset="UTF-8">
+    <title>Paper Spinner</title>
+    <script src="../webcomponentsjs/webcomponents.js"></script>
+    <link rel="import" href="paper-spinner.html">
+    <style>
 
-  paper-spinner.yellow .circle {
-    border-color: #f4b400;
-  }
+      paper-spinner.blue .circle {
+        border-color: #4285f4;
+      }
 
-  paper-spinner.green .circle {
-    border-color: #0f9d58;
-  }
-  </style>
-</head>
-<body>
-  <paper-spinner class="blue" active></paper-spinner>
-  <paper-spinner class="red" active></paper-spinner>
-  <paper-spinner class="yellow" active></paper-spinner>
-  <paper-spinner class="green" active></paper-spinner>
-  <paper-spinner active></paper-spinner>
-  <button>Toggle</button>
-  <script>
-    document.querySelector('button').addEventListener('click', function() {
+      paper-spinner.red .circle {
+        border-color: #db4437;
+      }
+
+      paper-spinner.yellow .circle {
+        border-color: #f4b400;
+      }
+
+      paper-spinner.green .circle {
+        border-color: #0f9d58;
+      }
+
+    </style>
+  </head>
+
+  <body>
+    <paper-spinner class="blue" active></paper-spinner>
+    <paper-spinner class="red" active></paper-spinner>
+    <paper-spinner class="yellow" active></paper-spinner>
+    <paper-spinner class="green" active></paper-spinner>
+    <paper-spinner active></paper-spinner>
+    <button>Toggle</button>
+
     <script>
       var spinners = document.querySelectorAll('paper-spinner');
 
@@ -49,5 +52,7 @@
           spinner.active = !spinner.active;
         });
       });
-</body>
+    </script>
+  </body>
+
 </html>

--- a/demo.html
+++ b/demo.html
@@ -41,11 +41,13 @@
   <button>Toggle</button>
   <script>
     document.querySelector('button').addEventListener('click', function() {
+    <script>
       var spinners = document.querySelectorAll('paper-spinner');
-      Array.prototype.forEach.call(spinners, function(spinner) {
-        spinner.active = !spinner.active;
+
+      document.querySelector('button').addEventListener('click', function() {
+        Array.prototype.forEach.call(spinners, function(spinner) {
+          spinner.active = !spinner.active;
+        });
       });
-    });
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,15 +8,15 @@
   subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
 -->
 <html>
-<head>
+  <head>
 
-  <script src="../webcomponentsjs/webcomponents.js"></script>
-  <link rel="import" href="../core-component-page/core-component-page.html">
+    <script src="../webcomponentsjs/webcomponents.js"></script>
+    <link rel="import" href="../core-component-page/core-component-page.html">
 
-</head>
-<body unresolved>
+  </head>
+  <body unresolved>
 
-  <core-component-page></core-component-page>
+    <core-component-page></core-component-page>
 
-</body>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <!--
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
-The complete set of authors may be found at http://polymer.github.io/AUTHORS
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+  Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+  This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+  The complete set of authors may be found at http://polymer.github.io/AUTHORS
+  The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+  Code distributed by Google as part of the polymer project is also
+  subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
 -->
 <html>
 <head>

--- a/paper-spinner.css
+++ b/paper-spinner.css
@@ -1,11 +1,11 @@
 /*
-    @license
-    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
-    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-    Code distributed by Google as part of the polymer project is also
-    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+  @license
+  Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+  This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+  The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+  The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+  Code distributed by Google as part of the polymer project is also
+  subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 /**************************/

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -205,8 +205,8 @@ in another form (e.g. a text block following the spinner).
       },
 
       reset: function() {
-        if (this.active) this.active = false;
-        if (this.coolingDown) this.coolingDown = false;
+        this.active = false;
+        this.coolingDown = false;
       }
 
     });

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -1,11 +1,11 @@
 <!--
-    @license
-    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
-    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-    Code distributed by Google as part of the polymer project is also
-    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+  @license
+  Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+  This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+  The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+  The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+  Code distributed by Google as part of the polymer project is also
+  subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="../polymer/polymer.html">
 

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -141,14 +141,6 @@ in another form (e.g. a text block following the spinner).
         alt: String
       },
 
-      /**
-       * True when the spinner is going from active to inactive. This is represented by a fade to 0%
-       * opacity to the user.
-       *
-       * @type boolean
-       */
-      coolingDown: false,
-
       bind: {
         active: 'activeChanged',
         alt: 'altChanged'
@@ -168,7 +160,13 @@ in another form (e.g. a text block following the spinner).
       configure: function() {
         return {
           active: false,
-          alt: 'loading'
+          alt: 'loading',
+
+          /**
+           * True when the spinner is going from active to inactive. This is represented by a fade
+           * to 0% opacity to the user.
+           */
+          coolingDown: false,
         };
       },
 

--- a/paper-spinner.html
+++ b/paper-spinner.html
@@ -8,6 +8,7 @@
   subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../layout/layout.html">
 
 <!--
 Element providing material design circular spinner.
@@ -40,57 +41,78 @@ in another form (e.g. a text block following the spinner).
 @homepage http://polymer.github.io/paper-spinner
 -->
 
-<link rel="stylesheet" href="paper-spinner.css">
+<dom-module id="paper-spinner">
 
-<!-- TODO(keanu): Code intentionally left indented to reduce diff. Fix when 0.8 is ready. -->
+  <link rel="stylesheet" href="paper-spinner.css">
+
   <template>
 
-    <div id="spinnerContainer">
+    <div id="spinnerContainer" class-name="[[spinnerContainerClassName]]">
       <div class="spinner-layer blue">
         <div class="circle-clipper left">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div><div class="gap-patch">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div><div class="circle-clipper right">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div>
       </div>
 
       <div class="spinner-layer red">
         <div class="circle-clipper left">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div><div class="gap-patch">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div><div class="circle-clipper right">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div>
       </div>
 
       <div class="spinner-layer yellow">
         <div class="circle-clipper left">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div><div class="gap-patch">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div><div class="circle-clipper right">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div>
       </div>
 
       <div class="spinner-layer green">
         <div class="circle-clipper left">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div><div class="gap-patch">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div><div class="circle-clipper right">
-          <div class="circle" fit></div>
+          <div class="circle fit"></div>
         </div>
       </div>
     </div>
+
   </template>
 
-  <script>
+</dom-module>
+
+<script>
+
+  (function() {
+
+    'use strict';
+
+    function classNames(obj) {
+      var classNames = [];
+      for (var key in obj) {
+        if (obj.hasOwnProperty(key) && obj[key]) {
+          classNames.push(key);
+        }
+      }
+
+      return classNames.join(' ');
+    }
+
     Polymer({
-      tag: 'paper-spinner',
+
+      is: 'paper-spinner',
 
       listeners: {
         'animationend': 'reset',
@@ -111,6 +133,7 @@ in another form (e.g. a text block following the spinner).
          * Alternative text content for accessibility support.
          * If alt is present, it will add an aria-label whose content matches alt when active.
          * If alt is not present, it will default to 'loading' as the alt value.
+         *
          * @attribute alt
          * @type string
          * @default 'loading'
@@ -118,9 +141,35 @@ in another form (e.g. a text block following the spinner).
         alt: String
       },
 
+      /**
+       * True when the spinner is going from active to inactive. This is represented by a fade to 0%
+       * opacity to the user.
+       *
+       * @type boolean
+       */
+      coolingDown: false,
+
       bind: {
         active: 'activeChanged',
         alt: 'altChanged'
+      },
+
+      computed: {
+        spinnerContainerClassName: 'calcSpinnerContainerClassName(active, coolingDown)'
+      },
+
+      calcSpinnerContainerClassName: function(active, coolingDown) {
+        return classNames({
+          active: active || coolingDown,
+          cooldown: coolingDown
+        });
+      },
+
+      configure: function() {
+        return {
+          active: false,
+          alt: 'loading'
+        };
       },
 
       ready: function() {
@@ -128,9 +177,9 @@ in another form (e.g. a text block following the spinner).
         if (this.hasAttribute('aria-label')) {
           this.alt = this.getAttribute('aria-label');
         } else {
-          this.alt = 'loading'
           this.setAttribute('aria-label', this.alt);
         }
+
         if (!this.active) {
           this.setAttribute('aria-hidden', 'true');
         }
@@ -138,11 +187,9 @@ in another form (e.g. a text block following the spinner).
 
       activeChanged: function() {
         if (this.active) {
-          this.$.spinnerContainer.classList.remove('cooldown');
-          this.$.spinnerContainer.classList.add('active');
           this.removeAttribute('aria-hidden');
         } else {
-          this.$.spinnerContainer.classList.add('cooldown');
+          this.coolingDown = true;
           this.setAttribute('aria-hidden', 'true');
         }
       },
@@ -153,11 +200,17 @@ in another form (e.g. a text block following the spinner).
         } else {
           this.removeAttribute('aria-hidden');
         }
+
         this.setAttribute('aria-label', this.alt);
       },
 
       reset: function() {
-        this.$.spinnerContainer.classList.remove('active', 'cooldown');
+        if (this.active) this.active = false;
+        if (this.coolingDown) this.coolingDown = false;
       }
+
     });
-  </script>
+
+  }());
+
+</script>


### PR DESCRIPTION
- Drive container class name off state rather than directly manipulate the DOM
- Use layout class name "fit" rather than attribute
- Use `classNames` function to simplify class name calculation
